### PR TITLE
fix: replace sample interface backend with cpu

### DIFF
--- a/ai_vision/sample_resnet101_quantized/sample_resnet101_quantized/qrb_ros_resnet101.py
+++ b/ai_vision/sample_resnet101_quantized/sample_resnet101_quantized/qrb_ros_resnet101.py
@@ -57,7 +57,7 @@ class ResNet101QuantizedNode(Node):
             
             cv_image.astype(np.uint8).tofile(workdir+"/input.raw")
         
-            command = f"cd {workdir}; qtld-net-run --model {self.model_path}/ResNet101Quantized.tflite --input {workdir}/input --output {workdir}/output --backend htp"
+            command = f"cd {workdir}; qtld-net-run --model {self.model_path}/ResNet101Quantized.tflite --input {workdir}/input --output {workdir}/output"
             subprocess.run(command, stdout=subprocess.DEVNULL, check=True, shell=True)
             result = self.process()
             self.publisher.publish(String(data=result))


### PR DESCRIPTION
qnn sdk backend htp will fail on rb8,so replace sample interface backend with cpu