### PR TITLE
fix: improve shutdown handling in hand_landmark

### DIFF
--- a/ai_vision/sample_hand_detection/launch/launch_with_qrb_ros_camera.py
+++ b/ai_vision/sample_hand_detection/launch/launch_with_qrb_ros_camera.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         'stream1': {
             'height': 480,
             'width': 640,
-            'fps': 5,
+            'fps': 30,
         },
         'camera_info_path': camera_info_config_file_path,
     }


### PR DESCRIPTION
- Add shutdown flag to prevent callbacks from executing during node destruction
- Add exception handling for all ROS2 operations during shutdown
- Improve shutdown sequence: executor -> node -> rclpy context
- Fix "cannot use Destroyable because destruction was requested" error
- Fix "publisher's context is invalid" warning during Ctrl+C shutdown