### PR TITLE
fix: remove ros-jazzy-sample-apriltag

### DIFF
--- a/qirp-sdk-desktop/debian/changelog
+++ b/qirp-sdk-desktop/debian/changelog
@@ -1,3 +1,10 @@
+qirp-sdk-desktop (2.4.2) noble; urgency=medium
+
+    * Modify depends
+    - Removed dependency on ros-jazzy-sample-apriltag
+    - Added Conflicts field to declare incompatibility with qcom-adreno1
+
+ -- Fulan Liu <fulaliu@qti.qualcomm.com>  Fri, 27 Feb 2026 14:27:04 +0800
 qirp-sdk-desktop (2.4.1) noble; urgency=medium
 
   * Add new ROS Jazzy packages in QIRP SDK.

--- a/qirp-sdk-desktop/debian/control
+++ b/qirp-sdk-desktop/debian/control
@@ -65,9 +65,9 @@ Depends: ${misc:Depends},
          ros-jazzy-ros2-benchmark-interfaces,
          ros-jazzy-ros-base,
          ros-jazzy-follow-me,
-         ros-jazzy-sample-apriltag,
          libqnn-dev,
          libqnn1,
          qnn-tools,
          python3-pip,
+Conflicts: qcom-adreno1
 Description: The Qualcomm® Intelligent Robotics (QIR) SDK is a collection of components that enable you to develop robotic features on Qualcomm platforms. This SDK is applicable to the Qualcomm Linux releases.


### PR DESCRIPTION
Remove ros-jazzy-sample-apriltag from desktop deb packages, only support on server deb packages