### PR TITLE
fix: resolve URDF path error and integrate pick-and-place node

### DIFF
--- a/ai_vision/sample_depth_estimation/README.md
+++ b/ai_vision/sample_depth_estimation/README.md
@@ -26,15 +26,19 @@
 
 ## 🔎 Table of contents
 
-  * [Used ROS Topics](#-used-ros-topics)
-  * [Supported targets](#-supported-targets)
-  * [Installation](#-installation)
-  * [Usage](#-usage)
-  * [Build from source](#-build-from-source)
-  * [Contributing](#-contributing)
-  * [Contributors](#%EF%B8%8F-contributors)
-  * [FAQs](#-faqs)
-  * [License](#-license)
+- [👋 Overview](#-overview)
+- [🔎 Table of contents](#-table-of-contents)
+- [⚓ Used ROS Topics](#-used-ros-topics)
+- [🎯 Supported targets](#-supported-targets)
+- [✨ Installation](#-installation)
+- [🚀 Usage](#-usage)
+- [👨‍💻 Visualization](#-visualization)
+- [👨‍💻 Prerequisites](#-prerequisites)
+- [👨‍💻 Build from source](#-build-from-source)
+- [🤝 Contributing](#-contributing)
+- [❤️ Contributors](#️-contributors)
+- [❔ FAQs](#-faqs)
+- [📜 License](#-license)
 
 ## ⚓ Used ROS Topics 
 
@@ -73,13 +77,6 @@
 > Refer to [Install Ubuntu on Qualcomm IoT Platforms](https://ubuntu.com/download/qualcomm-iot) and [Install ROS Jazzy](https://docs.ros.org/en/jazzy/index.html) to setup environment. <br>
 > For Qualcomm Linux, please check out the [Qualcomm Intelligent Robotics Product SDK](https://docs.qualcomm.com/bundle/publicresource/topics/80-70018-265/introduction_1.html?vproduct=1601111740013072&version=1.4&facet=Qualcomm%20Intelligent%20Robotics%20Product%20(QIRP)%20SDK) documents.
 
-
-## 🚀 Usage
-<details>
-  <summary>Install via Debian package</summary>
-
-## 👨‍💻 Prerequisites
-
 - Add qcom ppa repository source:
 ```bash
 sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
@@ -89,9 +86,12 @@ sudo apt update
 
 - Install the depth estimation Debian package: 
 ```bash
-
 sudo apt install -y ros-jazzy-sample-depth-estimation
 ```
+
+## 🚀 Usage
+<details>
+  <summary>Debian package usage details</summary>
 
 - Run sample depth estimation:
 ```bash

--- a/robotics/simulation_sample_pick_and_place/README.md
+++ b/robotics/simulation_sample_pick_and_place/README.md
@@ -131,13 +131,6 @@ export ROS_DOMAIN_ID=55
 ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
 ```
 
-- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
-```bash
-source /opt/ros/jazzy/setup.bash
-export ROS_DOMAIN_ID=55
-ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
-```
-
 - You can then view the arm executing the pick-and-place operation in Gazebo.
 
 </details>
@@ -212,13 +205,6 @@ colcon build
 source install/setup.bash
 export ROS_DOMAIN_ID=55
 ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
-```
-
-- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
-```bash
-source install/setup.bash
-export ROS_DOMAIN_ID=55
-ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
 ```
 
 - You can then view the arm executing the pick-and-place operation in Gazebo.

--- a/robotics/simulation_sample_pick_and_place/README.md
+++ b/robotics/simulation_sample_pick_and_place/README.md
@@ -28,6 +28,7 @@
 - [🎯 Supported targets](#-supported-targets)
 - [✨ Installation](#-installation)
 - [🚀 Usage](#-usage)
+- [👨‍💻 Build from source](#-build-from-source)
 - [🤝 Contributing](#-contributing)
 - [❤️ Contributors](#️-contributors)
 - [❔ FAQs](#-faqs)
@@ -83,12 +84,23 @@
 > Refer to [Install Ubuntu on Qualcomm IoT Platforms](https://ubuntu.com/download/qualcomm-iot) and [Install ROS Jazzy](https://docs.ros.org/en/jazzy/index.html) to set up the environment. <br>
 > For Qualcomm Linux, please check the [Qualcomm Intelligent Robotics Product SDK](https://docs.qualcomm.com/bundle/publicresource/topics/80-70018-265/introduction_1.html?vproduct=1601111740013072&version=1.4&facet=Qualcomm%20Intelligent%20Robotics%20Product%20(QIRP)%20SDK) documentation.
 
+- Add Qualcomm PPA repositories on device:
+```bash
+sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
+sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
+sudo apt update
+```
+
+- Install the pick-and-place Debian package on device: 
+```bash
+sudo apt install -y ros-jazzy-simulation-sample-pick-and-place ros-jazzy-moveit qcom-adreno-dev
+```
+
 ## 🚀 Usage
 
 The following steps assume a ROS 2 Jazzy + Gazebo environment. Follow the official installation docs to install [ROS 2 Jazzy](https://docs.ros.org/en/jazzy/Installation.html) and [Gazebo](https://gazebosim.org/docs/all/getstarted/). You can also use [qrb_ros_simulation](https://github.com/qualcomm-qrb-ros/qrb_ros_simulation/tree/main) to launch a Docker environment and run the steps.
-
 <details>
-  <summary>Install via Debian package</summary>
+  <summary>Debian package usage details</summary>
 
 1. Launch simulation environment on the HOST.
 
@@ -111,18 +123,6 @@ ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper_load_controller.launch.py
 - After Gazebo starts in the host Docker container, run the pick-and-place node on the device.
 
 2. The following steps run on a Qualcomm device (see the [Supported targets](#-supported-targets) table).
-
-- Add Qualcomm PPA repositories:
-```bash
-sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
-sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
-sudo apt update
-```
-
-- Install the pick-and-place Debian package: 
-```bash
-sudo apt install -y ros-jazzy-simulation-sample-pick-and-place ros-jazzy-moveit qcom-adreno-dev
-```
 
 - Launch MoveIt 2 and the demo to start the arm motion:
 ```bash

--- a/robotics/simulation_sample_pick_and_place/config/rml_63.srdf
+++ b/robotics/simulation_sample_pick_and_place/config/rml_63.srdf
@@ -3,7 +3,7 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-<robot name="rml_63">
+<robot name="rml_63_arm_robot">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->

--- a/robotics/simulation_sample_pick_and_place/config/rml_63.urdf.xacro
+++ b/robotics/simulation_sample_pick_and_place/config/rml_63.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rml_63">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rml_63_arm_robot">
   <xacro:arg name="topic_ns" default=""/>
   <!-- Import description urdf file -->
   <xacro:include filename="$(find simulation_sample_pick_and_place)/urdf/rml_63_gripper_arm/rml_63.urdf" />

--- a/robotics/simulation_sample_pick_and_place/launch/simulation_sample_pick_and_place.launch.py
+++ b/robotics/simulation_sample_pick_and_place/launch/simulation_sample_pick_and_place.launch.py
@@ -4,71 +4,55 @@
 from moveit_configs_utils import MoveItConfigsBuilder
 
 from launch import LaunchDescription
-from launch.actions import (
-    DeclareLaunchArgument,
-)
-from moveit_configs_utils.launch_utils import (
-    add_debuggable_node,
-    DeclareBooleanLaunchArg,
-)
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+from moveit_configs_utils.launch_utils import add_debuggable_node
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("rml_63", package_name="simulation_sample_pick_and_place").to_moveit_configs() 
+    # Keep the same config stem name used by this package (rml_63.*)
+    moveit_config = MoveItConfigsBuilder(
+        'rml_63', package_name='simulation_sample_pick_and_place'
+    ).to_moveit_configs()
 
     ld = LaunchDescription()
 
-    # launch move_group
-    generate_move_group_launch(ld, moveit_config)
+    # Common args
+    ld.add_action(DeclareLaunchArgument('use_sim_time', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('debug', default_value='false'))
+    ld.add_action(DeclareLaunchArgument('allow_trajectory_execution', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('publish_monitored_planning_scene', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('capabilities', default_value=''))
+    ld.add_action(DeclareLaunchArgument('disable_capabilities', default_value=''))
+    ld.add_action(DeclareLaunchArgument('publish_robot_description', default_value='false'))
+    ld.add_action(DeclareLaunchArgument('publish_robot_description_semantic', default_value='false'))
 
-    return ld
+    should_publish_scene = LaunchConfiguration('publish_monitored_planning_scene')
 
-
-def generate_move_group_launch(ld, moveit_config):
-
-    ld.add_action(DeclareBooleanLaunchArg("debug", default_value=False))
-    ld.add_action(
-        DeclareBooleanLaunchArg("allow_trajectory_execution", default_value=True)
-    )
-    ld.add_action(
-        DeclareBooleanLaunchArg("publish_monitored_planning_scene", default_value=True)
-    )
-    # load non-default MoveGroup capabilities (space separated)
-    ld.add_action(DeclareLaunchArgument("capabilities", default_value=""))
-    # inhibit these default MoveGroup capabilities (space separated)
-    ld.add_action(DeclareLaunchArgument("disable_capabilities", default_value=""))
-
-    # do not copy dynamics information from /joint_states to internal robot monitoring
-    # default to false, because almost nothing in move_group relies on this information
-    ld.add_action(DeclareBooleanLaunchArg("monitor_dynamics", default_value=False))
-
-    should_publish = LaunchConfiguration("publish_monitored_planning_scene")
-
+    # Host-collab mode: do not publish robot_description topics to avoid collisions
     move_group_configuration = {
-        "publish_robot_description_semantic": True,
-        "allow_trajectory_execution": LaunchConfiguration("allow_trajectory_execution"),
-        # Note: Wrapping the following values is necessary so that the parameter value can be the empty string
-        "capabilities": ParameterValue(
-            LaunchConfiguration("capabilities"), value_type=str
+        'allow_trajectory_execution': LaunchConfiguration('allow_trajectory_execution'),
+        'capabilities': ParameterValue(LaunchConfiguration('capabilities'), value_type=str),
+        'disable_capabilities': ParameterValue(
+            LaunchConfiguration('disable_capabilities'), value_type=str
         ),
-        "disable_capabilities": ParameterValue(
-            LaunchConfiguration("disable_capabilities"), value_type=str
-        ),
-        # Publish the planning scene of the physical robot so that rviz plugin can know actual robot
-        "publish_planning_scene": should_publish,
-        "publish_geometry_updates": should_publish,
-        "publish_state_updates": should_publish,
-        "publish_transforms_updates": should_publish,
-        "monitor_dynamics": False,
+        'publish_planning_scene': should_publish_scene,
+        'publish_geometry_updates': should_publish_scene,
+        'publish_state_updates': should_publish_scene,
+        'publish_transforms_updates': should_publish_scene,
+        'publish_robot_description': LaunchConfiguration('publish_robot_description'),
+        'publish_robot_description_semantic': LaunchConfiguration('publish_robot_description_semantic'),
+        'monitor_dynamics': False,
+        'use_sim_time': LaunchConfiguration('use_sim_time'),
     }
 
     trajectory_execution = {
-        "moveit_manage_controllers": False,
-        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
-        "trajectory_execution.allowed_goal_duration_margin": 0.5,
-        "trajectory_execution.allowed_start_tolerance": 0.15,
+        'moveit_manage_controllers': False,
+        'trajectory_execution.allowed_execution_duration_scaling': 1.2,
+        'trajectory_execution.allowed_goal_duration_margin': 0.5,
+        'trajectory_execution.allowed_start_tolerance': 0.15,
     }
 
     move_group_params = [
@@ -76,17 +60,30 @@ def generate_move_group_launch(ld, moveit_config):
         move_group_configuration,
         trajectory_execution,
     ]
-    move_group_params.append({"use_sim_time": True})
 
     add_debuggable_node(
         ld,
-        package="moveit_ros_move_group",
-        executable="move_group",
-        commands_file=str(moveit_config.package_path / "launch" / "gdb_settings.gdb"),
-        output="screen",
+        package='moveit_ros_move_group',
+        executable='move_group',
+        commands_file=str(moveit_config.package_path / 'launch' / 'gdb_settings.gdb'),
+        output='screen',
         parameters=move_group_params,
-        extra_debug_args=["--debug"],
-        # Set the display variable, in case OpenGL code is used internally
-        additional_env={"DISPLAY": ":0"},
+        extra_debug_args=['--debug'],
+        additional_env={'DISPLAY': ':0'},
     )
+
+    # Launch pick-and-place app in the same graph with explicit local description params.
+    ld.add_action(
+        Node(
+            package='simulation_sample_pick_and_place',
+            executable='qrb_ros_arm_pick_place',
+            output='screen',
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time')},
+                moveit_config.robot_description,
+                moveit_config.robot_description_semantic,
+            ],
+        )
+    )
+
     return ld


### PR DESCRIPTION
Motivation:
1. Update launch file to fix URDF path resolution when running in host mode.
2. Add pick-and-place node execution step to the launch sequence.
3. Updated the installation steps to include Debian package installation for the sample depth estimation and simulation sample pick-and-place.