### PR TITLE
fix: resolve URDF path error and integrate pick-and-place node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,6 @@ set(INSTALL_DIRS
     config
     scripts
     meshes
-    resource
     src
     urdf
 )

--- a/README.md
+++ b/README.md
@@ -2,23 +2,22 @@
 
 <div >
   <h1>Simulation Sample Pick and Place</h1>
-  <p align="center">
 </div>
 
-![](./resource/pick_and_place.gif)
+![](https://github.com/qualcomm-qrb-ros/qrb_ros_samples/blob/gif/robotics/simulation_sample_pick_and_place/resource/pick_and_place.gif)
 
 ---
 
 ## 👋 Overview
 
-- The RML-63 Robotic Arm Pick and Place Demo is a C++-based ROS2 node that demonstrates autonomous pick-and-place operations using MoveIt2 for motion planning and Gazebo for physics simulation.
+- The RML-63 Robotic Arm pick-and-place demo is a C++-based ROS 2 node that demonstrates autonomous pick-and-place operations using MoveIt 2 for motion planning and Gazebo for physics simulation.
 
 ![image-20250723181610392](./resource/pick_and_place_architecture.jpg)
 
 | Node Name                                                    | Function                                                     |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | qrb_ros_simulation | Sets up the Qualcomm robotic simulation environment. See [qrb_ros_simulation](https://github.com/qualcomm-qrb-ros/qrb_ros_simulation). |
-| qrb_ros_arm_pick_and_place     | Defines pick and place positions with ROS2 launch.py configuration parameter support. |
+| qrb_ros_arm_pick_place     | Defines pick-and-place positions with ROS 2 `launch.py` configuration parameter support. |
 
 
 ## 🔎 Table of contents
@@ -29,7 +28,6 @@
 - [🎯 Supported targets](#-supported-targets)
 - [✨ Installation](#-installation)
 - [🚀 Usage](#-usage)
-- [👨‍💻 Build from source](#-build-from-source)
 - [🤝 Contributing](#-contributing)
 - [❤️ Contributors](#️-contributors)
 - [❔ FAQs](#-faqs)
@@ -81,46 +79,87 @@
 ## ✨ Installation
 
 > [!IMPORTANT]
-> The following steps need to be run on **Qualcomm Ubuntu** and **ROS Jazzy**.<br>
-> Refer to [Install Ubuntu on Qualcomm IoT Platforms](https://ubuntu.com/download/qualcomm-iot) and [Install ROS Jazzy](https://docs.ros.org/en/jazzy/index.html) to setup environment. <br>
-> For Qualcomm Linux, please check out the [Qualcomm Intelligent Robotics Product SDK](https://docs.qualcomm.com/bundle/publicresource/topics/80-70018-265/introduction_1.html?vproduct=1601111740013072&version=1.4&facet=Qualcomm%20Intelligent%20Robotics%20Product%20(QIRP)%20SDK) documents.
+> The following steps need to be run on **Qualcomm Ubuntu** with **ROS Jazzy**.<br>
+> Refer to [Install Ubuntu on Qualcomm IoT Platforms](https://ubuntu.com/download/qualcomm-iot) and [Install ROS Jazzy](https://docs.ros.org/en/jazzy/index.html) to set up the environment. <br>
+> For Qualcomm Linux, please check the [Qualcomm Intelligent Robotics Product SDK](https://docs.qualcomm.com/bundle/publicresource/topics/80-70018-265/introduction_1.html?vproduct=1601111740013072&version=1.4&facet=Qualcomm%20Intelligent%20Robotics%20Product%20(QIRP)%20SDK) documentation.
 
 ## 🚀 Usage
 
-## 👨‍💻 Build from source
+The following steps assume a ROS 2 Jazzy + Gazebo environment. Follow the official installation docs to install [ROS 2 Jazzy](https://docs.ros.org/en/jazzy/Installation.html) and [Gazebo](https://gazebosim.org/docs/all/getstarted/). You can also use [qrb_ros_simulation](https://github.com/qualcomm-qrb-ros/qrb_ros_simulation/tree/main) to launch a Docker environment and run the steps.
 
 <details>
-  <summary>Usage details</summary>
+  <summary>Install via Debian package</summary>
 
-1. Prerequisites
+1. Launch simulation environment on the HOST.
 
-- Add qcom-iot PPA repository source.
+- If you launch the simulation on a different host, use the same `ROS_DOMAIN_ID` to ensure devices can communicate via ROS.
+
+- You can launch Gazebo with the following command:
+```bash
+source install/setup.bash
+export ROS_DOMAIN_ID=55
+ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper.launch.py world_model:=warehouse initial_x:=2.2 initial_y:=-2 initial_z:=1.025 initial_yaw:=3.14159 initial_pitch:=0.0 initial_roll:=0.0 use_sim_time:=true
+```
+
+- After the world loads, click `Play` in Gazebo. In another terminal, launch the controller:
+```bash
+source install/setup.bash
+export ROS_DOMAIN_ID=55
+ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper_load_controller.launch.py
+```
+
+- After Gazebo starts in the host Docker container, run the pick-and-place node on the device.
+
+2. The following steps run on a Qualcomm device (see the [Supported targets](#-supported-targets) table).
+
+- Add Qualcomm PPA repositories:
 ```bash
 sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
 sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
 sudo apt update
 ```
 
-- Install dependencies:
+- Install the pick-and-place Debian package: 
 ```bash
-sudo apt install -y ros-dev-tools
+sudo apt install -y ros-jazzy-simulation-sample-pick-and-place ros-jazzy-moveit qcom-adreno-dev
+```
+
+- Launch MoveIt 2 and the demo to start the arm motion:
+```bash
+source /opt/ros/jazzy/setup.bash
+export ROS_DOMAIN_ID=55
+ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
+```
+
+- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
+```bash
+source /opt/ros/jazzy/setup.bash
+export ROS_DOMAIN_ID=55
+ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
+```
+
+- You can then view the arm executing the pick-and-place operation in Gazebo.
+
+</details>
+
+<details>
+  <summary>Build from source usage details</summary>
+
+## 👨‍💻 Build from source
+
+1. Launch simulation environment on the HOST.
+
+- Install ROS dependencies:
+```bash
+sudo apt update
+sudo apt-get install -y qcom-adreno-dev
 sudo apt install -y ros-jazzy-moveit
-``` 
-
-- Download source code from the qrb-ros-sample repository:
-```bash
-mkdir -p ~/qrb_ros_sample_ws/src && cd ~/qrb_ros_sample_ws/src
-git clone -b jazzy-rel https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
+sudo apt install -y ros-dev-tools
+sudo rosdep init
+rosdep update
 ```
 
-- Build the sample from source code:
-```bash
-cd ~/qrb_ros_sample_ws/src/qrb_ros_samples/robotics/simulation_sample_pick_and_place
-rosdep install -i --from-path ./ --rosdistro jazzy -y
-colcon build
-```
-
-2. Launch Gazebo on HOST Docker
+2. Launch Gazebo on the host Docker container
 
 - Please refer to the Quick Start of [QRB ROS Simulation](https://github.com/qualcomm-qrb-ros/qrb_ros_simulation) to launch `QRB Robot ARM` on the host. Use the same local network and `ROS_DOMAIN_ID` to ensure devices can communicate via ROS.
 
@@ -131,38 +170,65 @@ export ROS_DOMAIN_ID=55
 ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper.launch.py world_model:=warehouse initial_x:=2.2 initial_y:=-2 initial_z:=1.025 initial_yaw:=3.14159 initial_pitch:=0.0 initial_roll:=0.0 use_sim_time:=true
 ```
 
-- Click the play button in Gazebo after the world environment renders, open another terminal, and use the following command to launch the controller:
+- After the world loads, click `Play` in Gazebo. In another terminal, launch the controller:
 ```bash
 source install/setup.bash
 export ROS_DOMAIN_ID=55
 ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper_load_controller.launch.py
+```
+
+- After Gazebo starts in the host Docker container, you can run the pick-and-place node on the device.
+
+2. Launch pick-and-place node on the Qualcomm device (see [Supported targets](#-supported-targets)):
+
+- Install ROS dependencies:
+```bash
+sudo apt update
+sudo apt-get install -y qcom-adreno-dev
+sudo apt install -y ros-jazzy-moveit
+sudo apt install -y ros-dev-tools
+sudo rosdep init
+rosdep update
 ``` 
 
-- Ensure that after starting Gazebo ain the host Docker, you can then run the pick and place node.
+- Download the source code from the `qrb_ros_samples` repository:
 
-3. Run the pick and place node
+```bash
+mkdir -p ~/qrb_ros_sample_ws/src && cd ~/qrb_ros_sample_ws/src
+git clone -b jazzy-rel https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
+```
 
-- You can launch the MoveIt2 configuration and demo launch file to start the arm motion:
+- Build the sample from source:
+```bash
+cd ~/qrb_ros_sample_ws/src/qrb_ros_samples/robotics/simulation_sample_pick_and_place
+rosdep install -i --from-path ./ --rosdistro jazzy -y
+source /opt/ros/jazzy/setup.bash
+colcon build
+
+```
+
+- Launch MoveIt 2 and the demo to start the arm motion:
 ```bash
 source install/setup.bash
 export ROS_DOMAIN_ID=55
 ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
 ```
-- If the arm motion works normally, open another terminal and use the following command to start the pick and place node:
+
+- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
 ```bash
 source install/setup.bash
 export ROS_DOMAIN_ID=55
 ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
 ```
 
-- You can then view the arm executing the pick and place operation in Gazebo.
+- You can then view the arm executing the pick-and-place operation in Gazebo.
 
 </details>
 
 ## 🤝 Contributing
 
 We love community contributions! Get started by reading our [CONTRIBUTING.md](CONTRIBUTING.md).<br>
-Feel free to create an issue for bug report, feature requests or any discussion💡.
+Feel free to create an issue for bug reports, feature requests, or any discussion 💡.
 
 ## ❤️ Contributors
 
@@ -182,8 +248,13 @@ Thanks to all our contributors who have helped make this project better!
 
 
 ## ❔ FAQs
-
+How do I move the Coke can to the origin pose?
+You can execute the following command to move the Coke can to the origin pose:
+```bash
+gz service -s /world/warehouse/set_pose --reqtype gz.msgs.Pose --reptype gz.msgs.Boolean --timeout 1000 --req 'name: "coke1", position: { x: 3, y: -2.0, z: 1.02 }, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 }'
+```
 
 ## 📜 License
 
 Project is licensed under the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) License. See [LICENSE](../../LICENSE) for the full license text.
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [🎯 Supported targets](#-supported-targets)
 - [✨ Installation](#-installation)
 - [🚀 Usage](#-usage)
+- [👨‍💻 Build from source](#-build-from-source)
 - [🤝 Contributing](#-contributing)
 - [❤️ Contributors](#️-contributors)
 - [❔ FAQs](#-faqs)
@@ -83,12 +84,23 @@
 > Refer to [Install Ubuntu on Qualcomm IoT Platforms](https://ubuntu.com/download/qualcomm-iot) and [Install ROS Jazzy](https://docs.ros.org/en/jazzy/index.html) to set up the environment. <br>
 > For Qualcomm Linux, please check the [Qualcomm Intelligent Robotics Product SDK](https://docs.qualcomm.com/bundle/publicresource/topics/80-70018-265/introduction_1.html?vproduct=1601111740013072&version=1.4&facet=Qualcomm%20Intelligent%20Robotics%20Product%20(QIRP)%20SDK) documentation.
 
+- Add Qualcomm PPA repositories on device:
+```bash
+sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
+sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
+sudo apt update
+```
+
+- Install the pick-and-place Debian package on device: 
+```bash
+sudo apt install -y ros-jazzy-simulation-sample-pick-and-place ros-jazzy-moveit qcom-adreno-dev
+```
+
 ## 🚀 Usage
 
 The following steps assume a ROS 2 Jazzy + Gazebo environment. Follow the official installation docs to install [ROS 2 Jazzy](https://docs.ros.org/en/jazzy/Installation.html) and [Gazebo](https://gazebosim.org/docs/all/getstarted/). You can also use [qrb_ros_simulation](https://github.com/qualcomm-qrb-ros/qrb_ros_simulation/tree/main) to launch a Docker environment and run the steps.
-
 <details>
-  <summary>Install via Debian package</summary>
+  <summary>Debian package usage details</summary>
 
 1. Launch simulation environment on the HOST.
 
@@ -112,30 +124,11 @@ ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper_load_controller.launch.py
 
 2. The following steps run on a Qualcomm device (see the [Supported targets](#-supported-targets) table).
 
-- Add Qualcomm PPA repositories:
-```bash
-sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
-sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
-sudo apt update
-```
-
-- Install the pick-and-place Debian package: 
-```bash
-sudo apt install -y ros-jazzy-simulation-sample-pick-and-place ros-jazzy-moveit qcom-adreno-dev
-```
-
 - Launch MoveIt 2 and the demo to start the arm motion:
 ```bash
 source /opt/ros/jazzy/setup.bash
 export ROS_DOMAIN_ID=55
 ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
-```
-
-- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
-```bash
-source /opt/ros/jazzy/setup.bash
-export ROS_DOMAIN_ID=55
-ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
 ```
 
 - You can then view the arm executing the pick-and-place operation in Gazebo.
@@ -214,13 +207,6 @@ export ROS_DOMAIN_ID=55
 ros2 launch simulation_sample_pick_and_place simulation_sample_pick_and_place.launch.py
 ```
 
-- When the node starts, you should see a log beginning with `[move_group-1] You can start planning now!`. In another terminal, start the pick-and-place node:
-```bash
-source install/setup.bash
-export ROS_DOMAIN_ID=55
-ros2 run simulation_sample_pick_and_place qrb_ros_arm_pick_place
-```
-
 - You can then view the arm executing the pick-and-place operation in Gazebo.
 
 </details>
@@ -257,4 +243,3 @@ gz service -s /world/warehouse/set_pose --reqtype gz.msgs.Pose --reptype gz.msgs
 ## 📜 License
 
 Project is licensed under the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) License. See [LICENSE](../../LICENSE) for the full license text.
-

--- a/config/rml_63.srdf
+++ b/config/rml_63.srdf
@@ -3,7 +3,7 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-<robot name="rml_63">
+<robot name="rml_63_arm_robot">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->

--- a/config/rml_63.urdf.xacro
+++ b/config/rml_63.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 SPDX-License-Identifier: BSD-3-Clause-Clear -->
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rml_63">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rml_63_arm_robot">
   <xacro:arg name="topic_ns" default=""/>
   <!-- Import description urdf file -->
   <xacro:include filename="$(find simulation_sample_pick_and_place)/urdf/rml_63_gripper_arm/rml_63.urdf" />

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-jazzy-simulation-sample-pick-and-place (1.0.1.1) noble; urgency=high
+
+  * Resolve URDF path error and integrate pick-and-place node.
+
+ -- Teng Fan <tengf@qti.qualcomm.com>  Thu, 09 Apr 2026 06:34:48 -0000
+
 ros-jazzy-simulation-sample-pick-and-place (1.0.1) noble; urgency=high
 
   * Initial release for simulation sample pick and place.

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,5 +1,1 @@
-# Automatically add upstream changes to the quilt overlay.
-# http://manpages.ubuntu.com/manpages/trusty/man1/dpkg-source.1.html
-# This supports reusing the orig.tar.gz for debian increments.
-auto-commit
 

--- a/launch/simulation_sample_pick_and_place.launch.py
+++ b/launch/simulation_sample_pick_and_place.launch.py
@@ -4,71 +4,55 @@
 from moveit_configs_utils import MoveItConfigsBuilder
 
 from launch import LaunchDescription
-from launch.actions import (
-    DeclareLaunchArgument,
-)
-from moveit_configs_utils.launch_utils import (
-    add_debuggable_node,
-    DeclareBooleanLaunchArg,
-)
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+from moveit_configs_utils.launch_utils import add_debuggable_node
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("rml_63", package_name="simulation_sample_pick_and_place").to_moveit_configs() 
+    # Keep the same config stem name used by this package (rml_63.*)
+    moveit_config = MoveItConfigsBuilder(
+        'rml_63', package_name='simulation_sample_pick_and_place'
+    ).to_moveit_configs()
 
     ld = LaunchDescription()
 
-    # launch move_group
-    generate_move_group_launch(ld, moveit_config)
+    # Common args
+    ld.add_action(DeclareLaunchArgument('use_sim_time', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('debug', default_value='false'))
+    ld.add_action(DeclareLaunchArgument('allow_trajectory_execution', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('publish_monitored_planning_scene', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('capabilities', default_value=''))
+    ld.add_action(DeclareLaunchArgument('disable_capabilities', default_value=''))
+    ld.add_action(DeclareLaunchArgument('publish_robot_description', default_value='false'))
+    ld.add_action(DeclareLaunchArgument('publish_robot_description_semantic', default_value='false'))
 
-    return ld
+    should_publish_scene = LaunchConfiguration('publish_monitored_planning_scene')
 
-
-def generate_move_group_launch(ld, moveit_config):
-
-    ld.add_action(DeclareBooleanLaunchArg("debug", default_value=False))
-    ld.add_action(
-        DeclareBooleanLaunchArg("allow_trajectory_execution", default_value=True)
-    )
-    ld.add_action(
-        DeclareBooleanLaunchArg("publish_monitored_planning_scene", default_value=True)
-    )
-    # load non-default MoveGroup capabilities (space separated)
-    ld.add_action(DeclareLaunchArgument("capabilities", default_value=""))
-    # inhibit these default MoveGroup capabilities (space separated)
-    ld.add_action(DeclareLaunchArgument("disable_capabilities", default_value=""))
-
-    # do not copy dynamics information from /joint_states to internal robot monitoring
-    # default to false, because almost nothing in move_group relies on this information
-    ld.add_action(DeclareBooleanLaunchArg("monitor_dynamics", default_value=False))
-
-    should_publish = LaunchConfiguration("publish_monitored_planning_scene")
-
+    # Host-collab mode: do not publish robot_description topics to avoid collisions
     move_group_configuration = {
-        "publish_robot_description_semantic": True,
-        "allow_trajectory_execution": LaunchConfiguration("allow_trajectory_execution"),
-        # Note: Wrapping the following values is necessary so that the parameter value can be the empty string
-        "capabilities": ParameterValue(
-            LaunchConfiguration("capabilities"), value_type=str
+        'allow_trajectory_execution': LaunchConfiguration('allow_trajectory_execution'),
+        'capabilities': ParameterValue(LaunchConfiguration('capabilities'), value_type=str),
+        'disable_capabilities': ParameterValue(
+            LaunchConfiguration('disable_capabilities'), value_type=str
         ),
-        "disable_capabilities": ParameterValue(
-            LaunchConfiguration("disable_capabilities"), value_type=str
-        ),
-        # Publish the planning scene of the physical robot so that rviz plugin can know actual robot
-        "publish_planning_scene": should_publish,
-        "publish_geometry_updates": should_publish,
-        "publish_state_updates": should_publish,
-        "publish_transforms_updates": should_publish,
-        "monitor_dynamics": False,
+        'publish_planning_scene': should_publish_scene,
+        'publish_geometry_updates': should_publish_scene,
+        'publish_state_updates': should_publish_scene,
+        'publish_transforms_updates': should_publish_scene,
+        'publish_robot_description': LaunchConfiguration('publish_robot_description'),
+        'publish_robot_description_semantic': LaunchConfiguration('publish_robot_description_semantic'),
+        'monitor_dynamics': False,
+        'use_sim_time': LaunchConfiguration('use_sim_time'),
     }
 
     trajectory_execution = {
-        "moveit_manage_controllers": False,
-        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
-        "trajectory_execution.allowed_goal_duration_margin": 0.5,
-        "trajectory_execution.allowed_start_tolerance": 0.15,
+        'moveit_manage_controllers': False,
+        'trajectory_execution.allowed_execution_duration_scaling': 1.2,
+        'trajectory_execution.allowed_goal_duration_margin': 0.5,
+        'trajectory_execution.allowed_start_tolerance': 0.15,
     }
 
     move_group_params = [
@@ -76,17 +60,30 @@ def generate_move_group_launch(ld, moveit_config):
         move_group_configuration,
         trajectory_execution,
     ]
-    move_group_params.append({"use_sim_time": True})
 
     add_debuggable_node(
         ld,
-        package="moveit_ros_move_group",
-        executable="move_group",
-        commands_file=str(moveit_config.package_path / "launch" / "gdb_settings.gdb"),
-        output="screen",
+        package='moveit_ros_move_group',
+        executable='move_group',
+        commands_file=str(moveit_config.package_path / 'launch' / 'gdb_settings.gdb'),
+        output='screen',
         parameters=move_group_params,
-        extra_debug_args=["--debug"],
-        # Set the display variable, in case OpenGL code is used internally
-        additional_env={"DISPLAY": ":0"},
+        extra_debug_args=['--debug'],
+        additional_env={'DISPLAY': ':0'},
     )
+
+    # Launch pick-and-place app in the same graph with explicit local description params.
+    ld.add_action(
+        Node(
+            package='simulation_sample_pick_and_place',
+            executable='qrb_ros_arm_pick_place',
+            output='screen',
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time')},
+                moveit_config.robot_description,
+                moveit_config.robot_description_semantic,
+            ],
+        )
+    )
+
     return ld

--- a/package.xml
+++ b/package.xml
@@ -2,13 +2,13 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>simulation_sample_pick_and_place</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>ROS2 package for robot arm pick and place operations using MoveIt</description>
   <maintainer email="tengf@qti.qualcomm.com">root</maintainer>
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>rclcpp</depend>
@@ -16,10 +16,6 @@
   <depend>trajectory_msgs</depend>
   <depend>std_msgs</depend>
   <depend>eigen_stl_containers</depend>
-
-  <exec_depend>moveit_configs_utils</exec_depend>
-  <exec_depend>moveit_planners</exec_depend>
-  <exec_depend>moveit_simple_controller_manager</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Motivation:

1. Update launch file to fix URDF path resolution when running in host mode.
2. Add pick-and-place node execution step to the launch sequence.
3. Updated the installation steps to include Debian package installation for simulation sample pick-and-place.