### PR TITLE
fix: update model label link

### DIFF
--- a/ai_vision/sample_resnet101/config/config.yaml
+++ b/ai_vision/sample_resnet101/config/config.yaml
@@ -2,4 +2,4 @@
 model:
   - ResNet101_w8a8.bin,https://huggingface.co/qualcomm/ResNet101/resolve/121564046ebb2353d4a0aa67bf89c11e0c8e80d9/ResNet101_w8a8.bin?download=true
 model_label:
-   - imagenet_labels.txt,https://raw.githubusercontent.com/quic/ai-hub-models/refs/heads/main/qai_hub_models/labels/imagenet_labels.txt
+   - imagenet_labels.txt,https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt


### PR DESCRIPTION
Update model label link in the sample image classification