### PR TITLE
docs: Arduino Hub sample validation

### DIFF
--- a/ai_vision/sample_hand_detection/README.md
+++ b/ai_vision/sample_hand_detection/README.md
@@ -70,6 +70,11 @@ The model is sourced from [**MediaPipe Hand Landmark Detector**](https://aihub.q
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
   </tr>
+  <tr>
+    <th>Camera Support</th>
+    <td>Orbbec Gemini 335L (USB)</td>
+    <td>Orbbec Gemini 335L (USB)</td>
+  </tr>
 </table>
 
 ---

--- a/ai_vision/sample_hand_detection/README.md
+++ b/ai_vision/sample_hand_detection/README.md
@@ -116,6 +116,9 @@ ros2 launch sample_hand_detection launch_with_qrb_ros_camera.py model_path:=/opt
 
 # Launch the sample hand detection node with usb_cam (USB webcam)
 ros2 launch sample_hand_detection launch_with_usb_cam.py model_path:=/opt/model/
+
+# Launch the sample hand detection node with Orbbec camera (USB)
+ros2 launch sample_hand_detection launch_with_orbbec_camera.py model_path:=/opt/model/
 ```
 
 > **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
@@ -171,6 +174,9 @@ source install/setup.bash
 ros2 launch sample_hand_detection launch_with_qrb_ros_camera.py model_path:=/opt/model/
 # Or launch with usb_cam (USB webcam)
 ros2 launch sample_hand_detection launch_with_usb_cam.py model_path:=/opt/model/
+
+# Or launch with Orbbec camera (USB)
+ros2 launch sample_hand_detection launch_with_orbbec_camera.py model_path:=/opt/model/
 ```
 
 > **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:

--- a/ai_vision/sample_object_detection/README.md
+++ b/ai_vision/sample_object_detection/README.md
@@ -66,6 +66,11 @@ Ultralytics YOLOv8 is a machine learning model that predicts bounding boxes, seg
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
   </tr>
+  <tr>
+    <th>Camera Support</th>
+    <td>Orbbec Gemini 335L (USB)</td>
+    <td>Orbbec Gemini 335L (USB)</td>
+  </tr>
 </table>
 
 

--- a/ai_vision/sample_object_detection/README.md
+++ b/ai_vision/sample_object_detection/README.md
@@ -135,6 +135,9 @@ ros2 launch sample_object_detection launch_with_qrb_ros_camera.py model:=/opt/mo
 
 # Or use usb_cam (USB webcam)
 ros2 launch sample_object_detection launch_with_usb_cam.py model:=/opt/model/yolov8_det_qcs9075.bin
+
+# Or use Orbbec camera (USB)
+ros2 launch sample_object_detection launch_with_orbbec_camera.py model:=/opt/model/yolov8_det_qcs9075.bin
 ```
 
 > **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:

--- a/ai_vision/sample_object_segmentation/README.md
+++ b/ai_vision/sample_object_segmentation/README.md
@@ -66,6 +66,11 @@ Ultralytics YOLOv8 is a machine learning model that predicts bounding boxes, seg
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
   </tr>
+  <tr>
+    <th>Camera Support</th>
+    <td>Orbbec Gemini 335L (USB)</td>
+    <td>Orbbec Gemini 335L (USB)</td>
+  </tr>
 </table>
 
 

--- a/ai_vision/sample_object_segmentation/README.md
+++ b/ai_vision/sample_object_segmentation/README.md
@@ -139,6 +139,9 @@ ros2 launch sample_object_segmentation launch_with_qrb_ros_camera.py model:=/opt
 
 # Or use usb_cam (USB webcam)
 ros2 launch sample_object_segmentation launch_with_usb_cam.py model:=/opt/model/yolov8_seg.tflite
+
+# Or use Orbbec camera (USB)
+ros2 launch sample_object_segmentation launch_with_orbbec_camera.py model:=/opt/model/yolov8_seg.tflite
 ```
 
 > **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:

--- a/ai_vision/sample_resnet101/README.md
+++ b/ai_vision/sample_resnet101/README.md
@@ -102,6 +102,8 @@ or # You can launch with qrb ros camera
 ros2 launch sample_resnet101 launch_with_qrb_ros_camera.py
 or # You can launch with usb_cam (USB webcam)
 ros2 launch sample_resnet101 launch_with_usb_cam.py
+or # You can launch with Orbbec camera (USB)
+ros2 launch sample_resnet101 launch_with_orbbec_camera.py
 ```
 
 > **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:

--- a/ai_vision/sample_resnet101/README.md
+++ b/ai_vision/sample_resnet101/README.md
@@ -62,6 +62,10 @@ The `sample_resnet101` is a Python-based ROS node that performs image classifica
     <th>GMSL Camera Support</th>
     <td>LI-VENUS-OX03F10-OAX40-GM2A-118H(YUV)</td>
   </tr>
+  <tr>
+    <th>Camera Support</th>
+    <td>Orbbec Gemini 335L (USB)</td>
+  </tr>
 </table>
 
 

--- a/robotics/sample_apriltag/README.md
+++ b/robotics/sample_apriltag/README.md
@@ -59,6 +59,10 @@ The `sample_apriltag` is the ROS package to provide AprilTag pipeline samples fo
     <th>Hardware Overview</th>
     <th><a href="https://www.qualcomm.com/products/internet-of-things/industrial-processors/iq9-series/iq-9075"><img src="https://s7d1.scene7.com/is/image/dmqualcommprod/dragonwing-IQ-9075-EVK?$QC_Responsive$&fmt=png-alpha" width="160"></a></th>
   </tr>
+  <tr>
+    <th>Camera Support</th>
+    <td>Orbbec Gemini 335L (USB)</td>
+  </tr>
 </table>
 
 
@@ -152,6 +156,17 @@ detections:
 ```
 
 We can see it detected tag: `tagStandard41h12` and the tag id is `1`.
+
+### Start with an Orbbec USB camera
+
+If you use a USB Orbbec camera (e.g. Gemini 335L) instead of a MIPI camera, launch the Orbbec variant. It subscribes to `orbbec_camera` directly (RGB8 + `camera_info`) and skips `qrb_ros_camera` / color-space conversion, so Wayland/weston is not required:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+ros2 launch sample_apriltag sample_apriltag_orbbec.launch.py
+```
+
+> **Note:** This launch requires the `orbbec_camera` package (`ros-jazzy-orbbec-camera`). You may also need to install the Orbbec udev rules so the camera can be opened without root privileges.
 
 ### How to change camera id
 

--- a/robotics/sample_apriltag/launch/sample_apriltag_orbbec.launch.py
+++ b/robotics/sample_apriltag/launch/sample_apriltag_orbbec.launch.py
@@ -1,0 +1,79 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import os
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+    apriltag_conf = LaunchConfiguration("apriltag_conf")
+    apriltag_conf_arg = DeclareLaunchArgument(
+        "apriltag_conf",
+        default_value=os.path.join(
+            get_package_share_directory("sample_apriltag"),
+            "config",
+            "tags_41h12.yaml",
+        ),
+    )
+
+    # rectify: subscribes to Orbbec's rgb8 + camera_info, publishes /apriltag/image_rect
+    rectify = ComposableNode(
+        name="rectify",
+        package="image_proc",
+        plugin="image_proc::RectifyNode",
+        extra_arguments=[{"use_intra_process_comms": True}],
+        remappings=[
+            ("image", "/camera/color/image_raw"),
+            ("camera_info", "/camera/color/camera_info"),
+            ("image_rect", "/apriltag/image_rect"),
+        ],
+    )
+
+    # apriltag_ros/AprilTagNode: subscribes to image_rect + camera_info, publishes /apriltag/detections + /tf
+    apriltag = ComposableNode(
+        name="apriltag",
+        package="apriltag_ros",
+        plugin="AprilTagNode",
+        namespace="apriltag",
+        parameters=[apriltag_conf],
+        extra_arguments=[{"use_intra_process_comms": True}],
+        remappings=[
+            ("image_rect", "/apriltag/image_rect"),
+            ("camera_info", "/camera/color/camera_info"),
+        ],
+    )
+
+    container = ComposableNodeContainer(
+        name="apriltag_container",
+        namespace="",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[rectify, apriltag],
+        output="screen",
+    )
+
+    orbbec_launch = os.path.join(
+        get_package_share_directory("orbbec_camera"),
+        "launch",
+        "gemini_330_series.launch.py",
+    )
+    orbbec = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(orbbec_launch),
+        launch_arguments={
+            "color_width": "1280",
+            "color_height": "720",
+            "color_fps": "30",
+            "color_qos": "default",
+            "enable_depth": "false",
+            "enable_point_cloud": "false",
+            "depth_registration": "false",
+        }.items(),
+    )
+
+    return LaunchDescription([apriltag_conf_arg, container, orbbec])


### PR DESCRIPTION
## Summary
- `sample_hand_detection`, `sample_object_detection`, `sample_object_segmentation` and `sample_resnet101` already ship a `launch_with_orbbec_camera.py`, but their README only documented the `qrb_ros_camera` and `usb_cam` variants. Added the missing Orbbec usage line to each.
- `sample_apriltag` hard-codes `qrb_ros_camera` (MIPI IMX577) + `qrb_ros_colorspace_convert`, which requires Wayland/weston and an on-board MIPI camera. Added `launch/sample_apriltag_orbbec.launch.py` for boards with only a USB Orbbec camera (e.g. Gemini 335L): it includes `orbbec_camera`'s `gemini_330_series.launch.py` (already rgb8 + camera_info) directly into `rectify` + `apriltag_ros`, skipping `qrb_ros_camera` and color-space conversion entirely. Also added an Orbbec row to the Supported targets table and a usage section in the README.

## Test plan
- [x] Verified `sample_apriltag_orbbec.launch.py` end-to-end on a Gemini 335L: printed `tagStandard41h12` markers (id 1/2/3) detected with `hamming: 0` across 68 frames, via `/apriltag/detections`.
- [ ] Doc-only changes for the 4 ai_vision samples (no functional code change, launch scripts were already present and working).