### PR TITLE
docs: update grasp perceptrion and depth estimation README for addressed issues

### DIFF
--- a/ai_vision/sample_depth_estimation/README.md
+++ b/ai_vision/sample_depth_estimation/README.md
@@ -110,15 +110,9 @@ ros2 launch sample_depth_estimation launch_with_image_publisher.py image_path:=<
 ros2 launch sample_depth_estimation launch_with_qrb_ros_camera.py
 ```
 
-- You can launch with `usb_cam` if you connect a USB webcam:
-```bash
-ros2 launch sample_depth_estimation launch_with_usb_cam.py
-```
-
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_depth_estimation launch_with_usb_cam.py brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 ## 👨‍💻 Visualization
 

--- a/robotics/sample_robot_arm_grasping_with_pose_estimation/README.md
+++ b/robotics/sample_robot_arm_grasping_with_pose_estimation/README.md
@@ -88,7 +88,8 @@ Typical hardware: **Orbbec D335** (or compatible RGB-D) + **RML63** arm with ven
 
 1. Prerequisites installation
     ```bash
-    cd robotics/sample_robot_arm_grasping_with_pose_estimation/scripts
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
+    cd qrb_ros_samples/robotics/sample_robot_arm_grasping_with_pose_estimation/scripts
     chmod +x install.bash && bash install.bash
     ```
 
@@ -102,6 +103,18 @@ Typical hardware: **Orbbec D335** (or compatible RGB-D) + **RML63** arm with ven
     export POSE_MODEL_PATH=<YOUR DCOMPRESSED PATH>/trained_checkpoints/trained_checkpoints/ycb/pose_model_26_0.012863246640872631.pth
     export REFINE_MODEL_PATH=<YOUR DCOMPRESSED PATH>/trained_checkpoints/trained_checkpoints/ycb/pose_refine_model_69_0.009449292959118935.pth
     bash install.bash --onnx_export
+    ```
+
+    - If has the ONNX models, move them to `robotics/sample_robot_arm_grasping_with_pose_estimation/grasp_perception/models/ycb_models` as shown below.
+
+    ```bash
+      ./
+      ├── ycb_models
+      │   ├── densefusion_ycb_posenet.onnx
+      │   ├── densefusion_ycb_refiner.onnx
+      │   └── external-data
+      └── yolo26n_seg_models
+          └── yolo26n-seg.onnx
     ```
 
 2. Using test command to ensure `Orbbec camera` works well.
@@ -148,24 +161,22 @@ export ROS_DOMAIN_ID=55   # optional; match your network
 ros2 launch grasp_perception inference_with_camera_stream.launch.py
 ```
 
-3. **Execution (real arm)** — in another terminal, with the same `ROS_DOMAIN_ID` if distributed:
+3. **Execution (real arm)** — in another terminal, first set the device IP for the RML63 connection via the Python API:
+```bash
+sudo ip addr add 192.168.1.101/24 dev end0
+sudo ip link set end0 up
+```
+
+4. Then launch the `grasp_execution` node for pick and place execution:
 
 ```bash
 source /path/to/your_ws/install/setup.bash
 export ROS_DOMAIN_ID=55 # optional; match your network
+
 # If not already installed editable:
 python grasp_execution/grasp_execution/src/main.py --ip 192.168.1.18 --pose-topic /pose_estimation_result
 ```
 
-4. **(Optional)Perception (offline scene folder)** — publishes synthetic `/camera/...` from files and runs the same node:
-
-```bash
-source /path/to/your_ws/install/setup.bash
-ros2 launch grasp_perception inference_with_local_file.launch.py \
-  scene_dir:=/path/to/scene_with_rgb_and_depth_subfolders
-```
-
-Adjust `scene_dir` to a directory that contains your recorded `rgb/` and `depth/` images (see launch file defaults for layout).
 
 </details>
 

--- a/robotics/simulation_sample_pick_and_place/README.md
+++ b/robotics/simulation_sample_pick_and_place/README.md
@@ -180,7 +180,7 @@ rosdep update
 
 ```bash
 mkdir -p ~/qrb_ros_sample_ws/src && cd ~/qrb_ros_sample_ws/src
-git clone -b jazzy-rel https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
+git clone https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
 ```
 
 - Build the sample from source:


### PR DESCRIPTION
## What changed:

# Documentation fix 1 for depth estimation
- Remove usb camera steps from debian usage as code base has not yet been uploaded to qualcomm-ppa source.
- Related issue: https://github.com/qualcomm-qrb-ros/qrb_ros_samples/issues/433

# Documentation fix 2 for pick and place
- Update pick-and-place checkout branch to default branch.
- Related issue: https://github.com/qualcomm-qrb-ros/qrb_ros_samples/issues/438

# Documentation fix 3 for vision grasp
- Add sync code steps via git clone. https://github.com/qualcomm-qrb-ros/qrb_ros_samples/issues/442 
- Add onnx models path if models existed. https://github.com/qualcomm-qrb-ros/qrb_ros_samples/issues/443
- Remove ROS launch steps with local input image pipeline.