### PR TITLE
fix: note missing USB camera launch code in Debian usage

### DIFF
--- a/ai_vision/sample_face_detection/README.md
+++ b/ai_vision/sample_face_detection/README.md
@@ -114,14 +114,11 @@ ros2 launch sample_face_detection launch_with_image_publisher.py model_path:=/op
 ros2 launch sample_face_detection launch_with_image_publisher.py image_path:=/opt/resource/xxx.jpg model_path:=/opt/model/
 or # You can launch with qrb_ros_camera lacunch file
 ros2 launch sample_face_detection launch_with_qrb_ros_camera.py  model_path:=/opt/model/
-or # You can launch with usb_cam (USB webcam)
-ros2 launch sample_face_detection launch_with_usb_cam.py  model_path:=/opt/model/
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_face_detection launch_with_usb_cam.py model_path:=/opt/model/ brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 When using this launch script, it will use the default parameters:
 

--- a/ai_vision/sample_hand_detection/README.md
+++ b/ai_vision/sample_hand_detection/README.md
@@ -119,17 +119,13 @@ ros2 launch sample_hand_detection launch_with_image_publisher.py image_path:=<pa
 # Launch the sample hand detection node with qrb_ros_camera ros node.
 ros2 launch sample_hand_detection launch_with_qrb_ros_camera.py model_path:=/opt/model/
 
-# Launch the sample hand detection node with usb_cam (USB webcam)
-ros2 launch sample_hand_detection launch_with_usb_cam.py model_path:=/opt/model/
-
 # Launch the sample hand detection node with Orbbec camera (USB)
 ros2 launch sample_hand_detection launch_with_orbbec_camera.py model_path:=/opt/model/
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_hand_detection launch_with_usb_cam.py model_path:=/opt/model/ brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 **Note**  
 > This sample demonstrates how to build a pipeline using our ROS nodes. Due to the large data transmission of AI model inputs and outputs within ROS, prolonged operation may lead to reduced frame rates. If this happens, please relaunch the ROS nodes to restore normal performance.

--- a/ai_vision/sample_hrnet_pose_estimation/README.md
+++ b/ai_vision/sample_hrnet_pose_estimation/README.md
@@ -119,14 +119,11 @@ export ROS_DOMAIN_ID=124
 ros2 launch sample_hrnet_pose_estimation launch_with_image_publisher.py image_path:=/opt/ros/jazzy/share/sample_hrnet_pose_estimation/input_image.jpg
 # Launch the sample with qrb ros camera.
 ros2 launch sample_hrnet_pose_estimation launch_with_qrb_ros_camera.py
-# Launch the sample with usb_cam (USB webcam)
-ros2 launch sample_hrnet_pose_estimation launch_with_usb_cam.py
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_hrnet_pose_estimation launch_with_usb_cam.py brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 Open a new terminal and use rqt to view topic `/pose_estimation_results`.
 

--- a/ai_vision/sample_object_detection/README.md
+++ b/ai_vision/sample_object_detection/README.md
@@ -138,17 +138,13 @@ mv coco.ymal /opt/
 source /opt/ros/jazzy/setup.bash
 ros2 launch sample_object_detection launch_with_qrb_ros_camera.py model:=/opt/model/yolov8_det_qcs9075.bin
 
-# Or use usb_cam (USB webcam)
-ros2 launch sample_object_detection launch_with_usb_cam.py model:=/opt/model/yolov8_det_qcs9075.bin
-
 # Or use Orbbec camera (USB)
 ros2 launch sample_object_detection launch_with_orbbec_camera.py model:=/opt/model/yolov8_det_qcs9075.bin
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_object_detection launch_with_usb_cam.py model:=/opt/model/yolov8_det_qcs9075.bin brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 The output for these commands:
 

--- a/ai_vision/sample_object_segmentation/README.md
+++ b/ai_vision/sample_object_segmentation/README.md
@@ -142,17 +142,13 @@ source /opt/ros/jazzy/setup.bash
 
 ros2 launch sample_object_segmentation launch_with_qrb_ros_camera.py model:=/opt/model/yolov8_seg.tflite
 
-# Or use usb_cam (USB webcam)
-ros2 launch sample_object_segmentation launch_with_usb_cam.py model:=/opt/model/yolov8_seg.tflite
-
 # Or use Orbbec camera (USB)
 ros2 launch sample_object_segmentation launch_with_orbbec_camera.py model:=/opt/model/yolov8_seg.tflite
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_object_segmentation launch_with_usb_cam.py model:=/opt/model/yolov8_seg.tflite brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 The output for these commands:
 

--- a/ai_vision/sample_resnet101/README.md
+++ b/ai_vision/sample_resnet101/README.md
@@ -104,16 +104,13 @@ or # You can also replace this with a custom image file
 ros2 launch sample_resnet101 launch_with_image_publisher.py image_path:=<your image path>
 or # You can launch with qrb ros camera
 ros2 launch sample_resnet101 launch_with_qrb_ros_camera.py
-or # You can launch with usb_cam (USB webcam)
-ros2 launch sample_resnet101 launch_with_usb_cam.py
 or # You can launch with Orbbec camera (USB)
 ros2 launch sample_resnet101 launch_with_orbbec_camera.py
 ```
 
-> **Note:** For `usb_cam`, image quality parameters (`brightness`, `contrast`, `saturation`, `sharpness`, `gain`, and `focus`) default to `-1` (camera driver defaults). Override them as launch arguments to tune for your USB camera, for example:
-> ```bash
-> ros2 launch sample_resnet101 launch_with_usb_cam.py brightness:=128 contrast:=64 saturation:=80 sharpness:=50 gain:=0 focus:=0
-> ```
+> **Note:**
+The USB camera launch code has not yet been uploaded to qualcomm-ppa repository.
+For USB camera usage, refer to [Build from source](#-build-from-source).
 
 When using this launch script, it will use the default parameters:
 


### PR DESCRIPTION
## Description

`sample_depth_estimation`'s README already notes that the `launch_with_usb_cam.py` launch file has not yet been uploaded to the qualcomm-ppa repository, so it isn't available when installing via the Debian package (only via Build from source). The other ai_vision samples were missing this same note even though they have the identical gap.

This PR removes the `usb_cam` launch steps (and the associated image-quality-parameter note) from the Debian package **Usage** sections of:
- sample_face_detection
- sample_hand_detection
- sample_hrnet_pose_estimation
- sample_object_detection
- sample_object_segmentation
- sample_resnet101

and replaces them with the same note used in `sample_depth_estimation`, pointing users to the **Build from source** section for USB camera usage. The `usb_cam` instructions already present in each sample's **Build from source** section are left untouched, since that launch file is present when building from source.

## Type of change

- [x] This change requires a documentation update

## Issue Number (if applicable)
N/A

## Solution Approach
Mirrored the fix already applied to `sample_depth_estimation` in commit 0b75528, applying the same doc change consistently across the remaining ai_vision samples.

## How Has This Been Tested?

Documentation-only change; verified via diff review that the removed `usb_cam` commands are still available under each sample's Build from source section.

- [x] Reviewed rendered README diffs for all 6 samples

**Test Configuration**:
* OS version: N/A
* Hardware: N/A
* SDK: N/A